### PR TITLE
fix: correct occured→occurred typo in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -90,7 +90,7 @@ def checkCaptcha():
 		print ("Successfully completed captcha.")
 		output = 1
 	else:
-		print("An error occured.")
+		print("An error occurred.")
 		output = 0
 	pyautogui.moveTo(CLOSE_LOCATION)
 	pyautogui.click()


### PR DESCRIPTION
Corrects the error message shown to users, fixing issue #14.

Changes:
- `run.py`: `print("An error occured.")` → `print("An error occurred.")`