### PR TITLE
fix: correct occured→occurred typo in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -90,7 +90,7 @@ def checkCaptcha():
 		print ("Successfully completed captcha.")
 		output = 1
 	else:
-		print("An error occured.")
+		print("An error occurred.")
 		output = 0
 	pyautogui.moveTo(CLOSE_LOCATION)
 	pyautogui.click()


### PR DESCRIPTION
Fix a simple typo in the error message output: 'An error occured.' → 'An error occurred.' (run.py line 93).

This is a user-facing error message, so the typo is visible to users of this captcha solver tool.

**Changes:**
- 1 file changed (run.py)
- 1 line modified

Thanks!